### PR TITLE
Fixed link to the Kajam

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -414,7 +414,7 @@ const config = {
            href: 'https://blog.replit.com',
            target: '_blank'},
           {label: 'Jam',
-           href: 'https://replit.com/site/kajam',
+           href: 'https://kajam.replit.com',
            target: '_blank'},
           {type: 'search',
           position: 'right'},


### PR DESCRIPTION
The Kajam link on docs.replit.com currently points to https://replit.com/site/kajam which returns a 404 - I've changed it to point to https://kajam.replit.com/